### PR TITLE
コメント行が連続している部分についてbegin-endの方式のコメント形式に変更

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -24,6 +24,7 @@ Window.loop do
     obj.move
     obj.draw
   end
+=begin
   # if Input.keyPush?(K_SPACE)
   # # if Input.keyPush?(K_SPACE) == true then
   #   for i in 0..2 do # iを0から9まで変えながらループ
@@ -34,6 +35,7 @@ Window.loop do
   #     end
   #   end
   # end
+=end
   if Input.key_push?(K_SPACE) then
     tmt = tomato.new(tomato_img)
     tmt.move

--- a/player.rb
+++ b/player.rb
@@ -14,8 +14,9 @@ class Player
   def draw
     Window.draw($main_x, $main_y, @img)
   end
-   
-    # def tomato_throw
-    #     Tomato.new
-    # end
+=begin   
+    def tomato_throw
+        Tomato.new
+    end
+=end
 end


### PR DESCRIPTION
# 何をしたか
コメント行が連続している部分をbegin-endによるコメント形式に変更した

# 背景
Rubyでは、複数行に渡るコメントは、`#` ではなく、 `begin-end` が使えるため

# 期限
いつでも😉